### PR TITLE
Proof of concept: Migrate to web crypto from Node crypto

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1071,6 +1071,7 @@ packages/lib/services/debug/populateDatabase.js
 packages/lib/services/e2ee/EncryptionService.test.js
 packages/lib/services/e2ee/EncryptionService.js
 packages/lib/services/e2ee/RSA.node.js
+packages/lib/services/e2ee/constants.js
 packages/lib/services/e2ee/crypto.test.js
 packages/lib/services/e2ee/crypto.js
 packages/lib/services/e2ee/cryptoTestUtils.js

--- a/.gitignore
+++ b/.gitignore
@@ -1048,6 +1048,7 @@ packages/lib/services/debug/populateDatabase.js
 packages/lib/services/e2ee/EncryptionService.test.js
 packages/lib/services/e2ee/EncryptionService.js
 packages/lib/services/e2ee/RSA.node.js
+packages/lib/services/e2ee/constants.js
 packages/lib/services/e2ee/crypto.test.js
 packages/lib/services/e2ee/crypto.js
 packages/lib/services/e2ee/cryptoTestUtils.js

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -847,10 +847,10 @@ async function initialize(dispatch: Dispatch) {
 	if (Setting.value('env') === 'dev') {
 		if (Platform.OS !== 'web') {
 			await runRsaIntegrationTests();
-			await runCryptoIntegrationTests();
 		} else {
 			logger.info('Skipping encryption tests -- not supported on web.');
 		}
+		await runCryptoIntegrationTests();
 		await runOnDeviceFsDriverTests();
 	}
 

--- a/packages/app-mobile/services/e2ee/crypto.ts
+++ b/packages/app-mobile/services/e2ee/crypto.ts
@@ -1,20 +1,12 @@
 import { Crypto, CryptoBuffer, Digest, CipherAlgorithm, EncryptionResult, EncryptionParameters } from '@joplin/lib/services/e2ee/types';
+import { digestNameMap } from '@joplin/lib/services/e2ee/constants';
 import QuickCrypto from 'react-native-quick-crypto';
 import { HashAlgorithm } from 'react-native-quick-crypto/lib/typescript/keys';
 import type { CipherGCMOptions, CipherGCM, DecipherGCM } from 'crypto';
 
-type DigestNameMap = Record<Digest, HashAlgorithm>;
 
 const pbkdf2Raw = (password: string, salt: CryptoBuffer, iterations: number, keylen: number, digest: Digest): Promise<CryptoBuffer> => {
-	const digestNameMap: DigestNameMap = {
-		sha1: 'SHA-1',
-		sha224: 'SHA-224',
-		sha256: 'SHA-256',
-		sha384: 'SHA-384',
-		sha512: 'SHA-512',
-		ripemd160: 'RIPEMD-160',
-	};
-	const rnqcDigestName = digestNameMap[digest];
+	const rnqcDigestName = digestNameMap[digest] as HashAlgorithm;
 
 	return new Promise((resolve, reject) => {
 		QuickCrypto.pbkdf2(password, salt, iterations, keylen, rnqcDigestName, (error, result) => {

--- a/packages/app-mobile/utils/shim-init-react/index.web.ts
+++ b/packages/app-mobile/utils/shim-init-react/index.web.ts
@@ -5,6 +5,7 @@ import shimInitShared from './shimInitShared';
 import FsDriverWeb from '../fs-driver/fs-driver-rn.web';
 import { FetchBlobOptions } from '@joplin/lib/types';
 import JoplinError from '@joplin/lib/JoplinError';
+import joplinCrypto from '@joplin/lib/services/e2ee/crypto';
 
 const shimInit = () => {
 	type GetLocationOptions = { timeout?: number };
@@ -41,6 +42,7 @@ const shimInit = () => {
 		return fsDriver_;
 	};
 	shim.fsDriver = fsDriver;
+	shim.crypto = joplinCrypto;
 
 	shim.randomBytes = async (count: number) => {
 		const buffer = new Uint8Array(count);

--- a/packages/app-mobile/web/mocks/nodeCrypto.js
+++ b/packages/app-mobile/web/mocks/nodeCrypto.js
@@ -1,0 +1,2 @@
+
+exports.webcrypto = crypto;

--- a/packages/app-mobile/web/webpack.config.js
+++ b/packages/app-mobile/web/webpack.config.js
@@ -61,6 +61,7 @@ module.exports = {
 	resolve: {
 		alias: {
 			'react-native$': 'react-native-web',
+			'crypto': path.resolve(__dirname, 'mocks/nodeCrypto.js'),
 
 			// Map some modules that don't work on web to the empty dictionary.
 			'react-native-fingerprint-scanner': emptyLibraryMock,

--- a/packages/lib/services/e2ee/constants.ts
+++ b/packages/lib/services/e2ee/constants.ts
@@ -1,0 +1,12 @@
+import { Digest } from './types';
+
+export const digestNameMap: Record<Digest, string> = {
+	sha1: 'SHA-1',
+	sha224: 'SHA-224',
+	sha256: 'SHA-256',
+	sha384: 'SHA-384',
+	sha512: 'SHA-512',
+	ripemd160: 'RIPEMD-160',
+};
+
+export default digestNameMap;

--- a/packages/lib/services/e2ee/crypto.ts
+++ b/packages/lib/services/e2ee/crypto.ts
@@ -1,56 +1,67 @@
-import { Crypto, CryptoBuffer, Digest, CipherAlgorithm, EncryptionResult, EncryptionParameters } from './types';
-import { promisify } from 'util';
+import { Crypto, CryptoBuffer, Digest, EncryptionResult, EncryptionParameters, CipherAlgorithm } from './types';
 import {
-	randomBytes as nodeRandomBytes,
-	pbkdf2 as nodePbkdf2,
-	createCipheriv, createDecipheriv,
-	CipherGCMOptions, CipherGCM, DecipherGCM,
+	webcrypto,
 } from 'crypto';
+import { Buffer } from 'buffer';
+import digestNameMap from './constants';
 
-const pbkdf2Raw = (password: string, salt: CryptoBuffer, iterations: number, keylen: number, digest: Digest) => {
-	const pbkdf2Async = promisify(nodePbkdf2);
-	return pbkdf2Async(password, salt, iterations, keylen, digest);
+const pbkdf2Raw = async (password: string, salt: Uint8Array, iterations: number, keylenBytes: number, digest: Digest) => {
+	const digestName = digestNameMap[digest];
+	const encoder = new TextEncoder();
+	const key = await webcrypto.subtle.importKey(
+		'raw', encoder.encode(password), { name: 'PBKDF2' }, false, ['deriveBits'],
+	);
+	return Buffer.from(await webcrypto.subtle.deriveBits(
+		{ name: 'PBKDF2', salt, iterations, hash: digestName }, key, keylenBytes * 8,
+	));
 };
 
-const encryptRaw = (data: CryptoBuffer, algorithm: CipherAlgorithm, key: CryptoBuffer, iv: CryptoBuffer, authTagLength: number, associatedData: CryptoBuffer) => {
-
-	const cipher = createCipheriv(algorithm, key, iv, { authTagLength: authTagLength } as CipherGCMOptions) as CipherGCM;
-
-	cipher.setAAD(associatedData, { plaintextLength: Buffer.byteLength(data) });
-
-	const encryptedData = Buffer.concat([cipher.update(data), cipher.final()]);
-	const authTag = cipher.getAuthTag();
-
-	return Buffer.concat([encryptedData, authTag]);
+const loadEncryptDecryptKey = async (keyData: Uint8Array) => {
+	return await webcrypto.subtle.importKey(
+		'raw',
+		keyData,
+		{ name: 'AES-GCM' },
+		false,
+		['encrypt', 'decrypt'],
+	);
 };
 
-const decryptRaw = (data: CryptoBuffer, algorithm: CipherAlgorithm, key: CryptoBuffer, iv: CryptoBuffer, authTagLength: number, associatedData: CryptoBuffer) => {
+const encryptRaw = async (data: Uint8Array, key: Uint8Array, iv: Uint8Array, authTagLengthBytes: number, additionalData: Uint8Array) => {
+	const loadedKey = await loadEncryptDecryptKey(key);
+	return Buffer.from(await webcrypto.subtle.encrypt({
+		name: 'AES-GCM',
+		iv,
+		additionalData,
+		tagLength: authTagLengthBytes * 8,
+	}, loadedKey, data));
+};
 
-	const decipher = createDecipheriv(algorithm, key, iv, { authTagLength: authTagLength } as CipherGCMOptions) as DecipherGCM;
+const decryptRaw = async (data: Uint8Array, key: Uint8Array, iv: Uint8Array, authTagLengthBytes: number, associatedData: Uint8Array) => {
+	const loadedKey = await loadEncryptDecryptKey(key);
+	return Buffer.from(await webcrypto.subtle.decrypt({
+		name: 'AES-GCM',
+		iv,
+		additionalData: associatedData,
+		tagLength: authTagLengthBytes * 8,
+	}, loadedKey, data));
+};
 
-	const authTag = data.subarray(-authTagLength);
-	const encryptedData = data.subarray(0, data.byteLength - authTag.byteLength);
-	decipher.setAuthTag(authTag);
-	decipher.setAAD(associatedData, { plaintextLength: Buffer.byteLength(data) });
-
-	let decryptedData = null;
-	try {
-		decryptedData = Buffer.concat([decipher.update(encryptedData), decipher.final()]);
-	} catch (error) {
-		throw new Error(`Authentication failed! ${error}`);
+const validateEncryptionParameters = ({ cipherAlgorithm }: EncryptionParameters) => {
+	if (cipherAlgorithm !== CipherAlgorithm.AES_256_GCM) {
+		throw new Error(`Unsupported cipherAlgorithm: ${cipherAlgorithm}. Must be AES 256 GCM.`);
 	}
-
-	return decryptedData;
 };
 
 const crypto: Crypto = {
 
 	randomBytes: async (size: number) => {
-		const randomBytesAsync = promisify(nodeRandomBytes);
-		return randomBytesAsync(size);
+		const result = new Uint8Array(size);
+		webcrypto.getRandomValues(result);
+		return Buffer.from(result);
 	},
 
 	encrypt: async (password: string, salt: CryptoBuffer, data: CryptoBuffer, encryptionParameters: EncryptionParameters) => {
+		validateEncryptionParameters(encryptionParameters);
 
 		// Parameters in EncryptionParameters won't appear in result
 		const result: EncryptionResult = {
@@ -64,7 +75,7 @@ const crypto: Crypto = {
 		const iv = await crypto.randomBytes(12);
 
 		const key = await pbkdf2Raw(password, salt, encryptionParameters.iterationCount, encryptionParameters.keyLength, encryptionParameters.digestAlgorithm);
-		const encrypted = encryptRaw(data, encryptionParameters.cipherAlgorithm, key, iv, encryptionParameters.authTagLength, encryptionParameters.associatedData);
+		const encrypted = await encryptRaw(data, key, iv, encryptionParameters.authTagLength, encryptionParameters.associatedData);
 
 		result.iv = iv.toString('base64');
 		result.ct = encrypted.toString('base64');
@@ -73,12 +84,13 @@ const crypto: Crypto = {
 	},
 
 	decrypt: async (password: string, data: EncryptionResult, encryptionParameters: EncryptionParameters) => {
+		validateEncryptionParameters(encryptionParameters);
 
 		const salt = Buffer.from(data.salt, 'base64');
 		const iv = Buffer.from(data.iv, 'base64');
 
 		const key = await pbkdf2Raw(password, salt, encryptionParameters.iterationCount, encryptionParameters.keyLength, encryptionParameters.digestAlgorithm);
-		const decrypted = decryptRaw(Buffer.from(data.ct, 'base64'), encryptionParameters.cipherAlgorithm, key, iv, encryptionParameters.authTagLength, encryptionParameters.associatedData);
+		const decrypted = decryptRaw(Buffer.from(data.ct, 'base64'), key, iv, encryptionParameters.authTagLength, encryptionParameters.associatedData);
 
 		return decrypted;
 	},

--- a/packages/lib/services/e2ee/crypto.ts
+++ b/packages/lib/services/e2ee/crypto.ts
@@ -1,7 +1,5 @@
 import { Crypto, CryptoBuffer, Digest, EncryptionResult, EncryptionParameters, CipherAlgorithm } from './types';
-import {
-	webcrypto,
-} from 'crypto';
+import { webcrypto } from 'crypto';
 import { Buffer } from 'buffer';
 import digestNameMap from './constants';
 


### PR DESCRIPTION
# Summary

This pull request rewrites the CLI and desktop app's `crypto.ts` to use the web crypto API. This should allow the new encryption methods to be used on web, while using the same logic as on desktop.

See discussion on the [upstream pull request](https://github.com/laurent22/joplin/pull/10696) for additional details.

# Testing

**Note**: At present, this is mostly untested. However, automated e2ee tests and integrated web tests pass.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->